### PR TITLE
Added visitor pattern to drawable entities

### DIFF
--- a/crocket/src/main/java/com/crocket/Application.java
+++ b/crocket/src/main/java/com/crocket/Application.java
@@ -22,7 +22,7 @@ public class Application {
 
     private static void init() {
         CroquetView frame = CroquetView.getInstance();
-        ILevel Level1 = new Level1();
+        Level Level1 = new Level1();
         LevelView level1View = new LevelView();
 
         IModel model = Model.getInstance();

--- a/crocket/src/main/java/com/crocket/controller/CroquetController.java
+++ b/crocket/src/main/java/com/crocket/controller/CroquetController.java
@@ -37,7 +37,6 @@ public class CroquetController implements KeyListener {
                 break;
             case KeyEvent.VK_SPACE:
                 if (model.shotAllowed()) {
-                    view.setPowerMeterVisibility(true);
                     if (power >= maxPower) {
                         powerIsMax = true;
                     } else if (power <= 1) {

--- a/crocket/src/main/java/com/crocket/model/DirectionLine.java
+++ b/crocket/src/main/java/com/crocket/model/DirectionLine.java
@@ -2,7 +2,10 @@ package com.crocket.model;
 
 import com.crocket.model.entity.Ball;
 
-public class DirectionLine {
+import com.crocket.model.interfaces.IEntityVisitable;
+import com.crocket.model.interfaces.IEntityVisitor;
+
+public class DirectionLine implements IEntityVisitable {
     private int degreeAngle;
     private final double HEIGHT = 100;
     private final double WIDTH = 100;
@@ -65,5 +68,9 @@ public class DirectionLine {
         degreeAngle -= 5;
 
         setDegreeAngle(degreeAngle);
+    }
+
+    public void accept(IEntityVisitor visitor) {
+        visitor.visit(this);
     }
 }

--- a/crocket/src/main/java/com/crocket/model/DirectionLine.java
+++ b/crocket/src/main/java/com/crocket/model/DirectionLine.java
@@ -1,18 +1,18 @@
 package com.crocket.model;
 
+import com.crocket.model.entity.Ball;
+
 public class DirectionLine {
     private int degreeAngle;
-    private double height;
-    private double width;
+    private final double HEIGHT = 100;
+    private final double WIDTH = 100;
     private double xPosition;
     private double yPosition;
 
-    public DirectionLine(int degreeAngle, double xPosition, double yPosition, double height, double width){
+    public DirectionLine(int degreeAngle, double xPosition, double yPosition){
         setDegreeAngle(degreeAngle);
         this.xPosition = xPosition;
         this.yPosition = yPosition;
-        this.height = height;
-        this.width = width;
     }
 
     public int getDegreeAngle() {
@@ -28,35 +28,40 @@ public class DirectionLine {
     }
 
     public double getHeight() {
-        return height;
+        return HEIGHT;
     }
 
     public double getWidth() {
-        return width;
+        return WIDTH;
     }
 
-    public void setxPosition(double xPosition){
+    public void setxPosition(double xPosition) {
         this.xPosition = xPosition;
     }
 
-    public void setyPosition(double yPosition){
+    public void setyPosition(double yPosition) {
         this.yPosition = yPosition;
     }
 
-    public void setDegreeAngle(int degreeAngle){
+    public void setPositionToBall(Ball ball) {
+        setxPosition(ball.getxPosition() - WIDTH/2 + ball.getWidth()/2);
+        setyPosition(ball.getyPosition() - HEIGHT/2 + ball.getHeight()/2);
+    }
+
+    public void setDegreeAngle(int degreeAngle) {
         if(degreeAngle > 360 || degreeAngle < 0){
             degreeAngle = (((degreeAngle % 360) + 360) % 360);
         }
         this.degreeAngle = degreeAngle;
     }
 
-    public void incrementDegreeAngle(){
+    public void incrementDegreeAngle() {
         degreeAngle += 5;
 
         setDegreeAngle(degreeAngle);
     }
 
-    public void decrementDegreeAngle(){
+    public void decrementDegreeAngle() {
         degreeAngle -= 5;
 
         setDegreeAngle(degreeAngle);

--- a/crocket/src/main/java/com/crocket/model/DirectionLine.java
+++ b/crocket/src/main/java/com/crocket/model/DirectionLine.java
@@ -14,7 +14,7 @@ public class DirectionLine {
         setDegreeAngle(degreeAngle);
         this.xPosition = xPosition;
         this.yPosition = yPosition;
-    }
+    } 
 
     public int getDegreeAngle() {
         return degreeAngle;
@@ -26,8 +26,8 @@ public class DirectionLine {
 
     public double getyPosition() {
         return yPosition;
-    }
-
+    } 
+ 
     public double getHeight() {
         return HEIGHT;
     }

--- a/crocket/src/main/java/com/crocket/model/DirectionLine.java
+++ b/crocket/src/main/java/com/crocket/model/DirectionLine.java
@@ -1,7 +1,5 @@
 package com.crocket.model;
 
-import com.crocket.model.entity.Ball;
-
 import com.crocket.model.interfaces.IEntityVisitable;
 import com.crocket.model.interfaces.IEntityVisitor;
 

--- a/crocket/src/main/java/com/crocket/model/DirectionLine.java
+++ b/crocket/src/main/java/com/crocket/model/DirectionLine.java
@@ -1,9 +1,9 @@
 package com.crocket.model;
 
-import com.crocket.model.interfaces.IEntityVisitable;
+import com.crocket.model.entity.Ball;
 import com.crocket.model.interfaces.IEntityVisitor;
 
-public class DirectionLine implements IEntityVisitable {
+public class DirectionLine {
     private int degreeAngle;
     private final double HEIGHT = 100;
     private final double WIDTH = 100;

--- a/crocket/src/main/java/com/crocket/model/DrawableEntity.java
+++ b/crocket/src/main/java/com/crocket/model/DrawableEntity.java
@@ -10,7 +10,7 @@ public class DrawableEntity {
     private int rotation;
     private EntityType type;
     
-    public DrawableEntity(int xPosition, int yPosition, int width, int height, int rotation,  EntityType type) {
+    public DrawableEntity(int xPosition, int yPosition, int width, int height, int rotation, EntityType type) {
         this.xPosition = xPosition;
         this.yPosition = yPosition;
         this.width = width;
@@ -37,6 +37,14 @@ public class DrawableEntity {
 
     public int getRotation() {
         return rotation;
+    }
+    
+    public double getCosinus() {
+        return Math.cos(Math.toRadians(rotation));
+    }
+
+    public double getSinus() {
+        return Math.sin(Math.toRadians(rotation));
     }
 
     public EntityType getType() {

--- a/crocket/src/main/java/com/crocket/model/EntityDrawableVisitor.java
+++ b/crocket/src/main/java/com/crocket/model/EntityDrawableVisitor.java
@@ -14,7 +14,6 @@ import com.crocket.shared.EntityType;
 import com.crocket.shared.Direction;
 
 public class EntityDrawableVisitor implements IEntityVisitor { 
-
     private Set<DrawableEntity> drawableEntities;
 
     protected EntityDrawableVisitor() {

--- a/crocket/src/main/java/com/crocket/model/EntityDrawableVisitor.java
+++ b/crocket/src/main/java/com/crocket/model/EntityDrawableVisitor.java
@@ -15,7 +15,11 @@ import com.crocket.shared.Direction;
 
 public class EntityDrawableVisitor implements IEntityVisitor { 
 
-    Set<DrawableEntity> drawableEntities = new HashSet<DrawableEntity>();
+    private Set<DrawableEntity> drawableEntities;
+
+    protected EntityDrawableVisitor() {
+        drawableEntities = new HashSet<DrawableEntity>();   
+    }
 
     private static EntityType getEntityTypeFromClass(Class<?> type) {
         if (type == Ball.class) {
@@ -51,7 +55,7 @@ public class EntityDrawableVisitor implements IEntityVisitor {
         drawableEntities.add(new DrawableEntity(xPosition, yPosition, width, height, rotation, type));
     }
 
-    private int convertDirectionToDegress(Direction direction) {
+    private int toDegrees(Direction direction) {
         switch (direction) {
             case NORTH  :
                 return 0;
@@ -71,7 +75,7 @@ public class EntityDrawableVisitor implements IEntityVisitor {
     }
 
     public void visit(Hoop hoop) {
-        int rotation = convertDirectionToDegress(hoop.getDirection());
+        int rotation = toDegrees(hoop.getDirection());
         addDrawableEntity(hoop, rotation);
     }
 

--- a/crocket/src/main/java/com/crocket/model/EntityDrawableVisitor.java
+++ b/crocket/src/main/java/com/crocket/model/EntityDrawableVisitor.java
@@ -79,7 +79,8 @@ public class EntityDrawableVisitor implements IEntityVisitor {
     }
 
     public void visit(DirectionLine directionLine) {
-        addDrawableEntity(directionLine, 0);
+        int rotation = directionLine.getDegreeAngle();
+        addDrawableEntity(directionLine, rotation);
     }
 
     public Set<DrawableEntity> getDrawableEntities() {

--- a/crocket/src/main/java/com/crocket/model/EntityDrawableVisitor.java
+++ b/crocket/src/main/java/com/crocket/model/EntityDrawableVisitor.java
@@ -1,0 +1,86 @@
+package com.crocket.model;
+
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.crocket.model.entity.Ball;
+import com.crocket.model.entity.Entity;
+import com.crocket.model.entity.Hoop;
+import com.crocket.model.entity.Peg;
+import com.crocket.model.entity.Stone;
+import com.crocket.model.interfaces.IEntityVisitor;
+import com.crocket.shared.EntityType;
+import com.crocket.shared.Direction;
+
+public class EntityDrawableVisitor implements IEntityVisitor { 
+
+    Set<DrawableEntity> drawableEntities = new HashSet<DrawableEntity>();
+
+    private static EntityType getEntityTypeFromClass(Class<?> type) {
+        if (type == Ball.class) {
+            return EntityType.BALL;
+        } else if (type == Hoop.class) {
+            return EntityType.HOOP;
+        } else if (type == Peg.class) {
+            return EntityType.PEG;
+        } else if (type == Stone.class) {
+            return EntityType.STONE;
+        } else if (type == DirectionLine.class) {
+            return EntityType.DIRECTIONLINE;
+        } else {
+            throw new IllegalArgumentException("Unknown entity class");
+        }
+    }
+
+    private void addDrawableEntity(Entity entity, int rotation) {
+        int xPosition = (int) entity.getxPosition();
+        int yPosition = (int) entity.getyPosition();
+        int width = entity.getWidth();
+        int height = entity.getHeight();
+        EntityType type = getEntityTypeFromClass(entity.getClass());
+        drawableEntities.add(new DrawableEntity(xPosition, yPosition, width, height, rotation, type));
+    }
+
+    private void addDrawableEntity(DirectionLine directionLine, int rotation) {
+        int xPosition = (int) directionLine.getxPosition();
+        int yPosition = (int) directionLine.getyPosition();
+        int width = (int) directionLine.getWidth();
+        int height = (int) directionLine.getHeight();
+        EntityType type = getEntityTypeFromClass(directionLine.getClass());
+        drawableEntities.add(new DrawableEntity(xPosition, yPosition, width, height, rotation, type));
+    }
+
+    private int convertDirectionToDegress(Direction direction) {
+        switch (direction) {
+            case NORTH  :
+                return 0;
+            case WEST:
+                return 90;
+            case SOUTH:
+                return 180; 
+            case EAST:
+                return 270; 
+            default:
+                throw new IllegalArgumentException("Unknown direction");
+        }
+    }
+
+    public void visit(Entity entity) {
+        addDrawableEntity(entity, 0);
+    }
+
+    public void visit(Hoop hoop) {
+        int rotation = convertDirectionToDegress(hoop.getDirection());
+        addDrawableEntity(hoop, rotation);
+    }
+
+    public void visit(DirectionLine directionLine) {
+        addDrawableEntity(directionLine, 0);
+    }
+
+    public Set<DrawableEntity> getDrawableEntities() {
+        return drawableEntities;
+    }
+}
+

--- a/crocket/src/main/java/com/crocket/model/Level1.java
+++ b/crocket/src/main/java/com/crocket/model/Level1.java
@@ -37,7 +37,7 @@ public class Level1 extends Level {
         super(width, height, tilemap);
         
         Stone s = new Stone(30, 30, 300, 500);
-        Hoop h = new Hoop(20, 40,32, 4,295, 450, Direction.WEST);
+        Hoop h = new Hoop(20, 40,32, 4,400, 280, Direction.WEST);
         Hoop h2 = new Hoop(40, 20,32, 4,400, 466, Direction.NORTH);
         Peg p = new Peg(5, 40, 309, 100);  
         

--- a/crocket/src/main/java/com/crocket/model/Level1.java
+++ b/crocket/src/main/java/com/crocket/model/Level1.java
@@ -37,11 +37,13 @@ public class Level1 extends Level {
         super(width, height, tilemap);
         
         Stone s = new Stone(30, 30, 300, 500);
-        Hoop h = new Hoop(40, 20,32, 4,295, 450, Direction.SOUTH);
+        Hoop h = new Hoop(20, 40,32, 4,295, 450, Direction.WEST);
+        Hoop h2 = new Hoop(40, 20,32, 4,400, 466, Direction.NORTH);
         Peg p = new Peg(5, 40, 309, 100);  
         
         addStone(s);
         addHoop(h);
+        addHoop(h2);
         addPeg(p);
     }
 

--- a/crocket/src/main/java/com/crocket/model/Model.java
+++ b/crocket/src/main/java/com/crocket/model/Model.java
@@ -164,9 +164,8 @@ public class Model implements IModel, IEventListener {
         validateLevelIsSet();
 
         EntityDrawableVisitor visitor = new EntityDrawableVisitor();
-
         for (Entity entity : entities) {
-            entity.accept(visitor);
+            entity.accept(visitor); 
         }
 
         if (shotAllowed) {

--- a/crocket/src/main/java/com/crocket/model/Model.java
+++ b/crocket/src/main/java/com/crocket/model/Model.java
@@ -51,7 +51,7 @@ public class Model implements IModel, IEventListener {
     private static final int DELAY = 20;
 
     private Model() {
-        directionLine = new DirectionLine(0, 0, 0, 0, 0);
+        directionLine = new DirectionLine(0, 0, 0);
         surfaceHandler = SurfaceHandler.getInstance();
         round = 0;
         ballIsMoving = false;
@@ -184,7 +184,7 @@ public class Model implements IModel, IEventListener {
         validateLevelIsSet();
 
         Set<DrawableEntity> drawableEntities = new HashSet<DrawableEntity>();
-
+        
         for (Entity entity : entities) {
             int xPosition = (int) entity.getxPosition();
             int yPosition = (int) entity.getyPosition();
@@ -199,9 +199,8 @@ public class Model implements IModel, IEventListener {
         if (shotAllowed) {
             // TODO: Should be fixed. This is an ugly hack to get the direction line to show
             // up. Breaks Law of Demeter.
-            directionLine.setxPosition(activePlayer.getBall().getxPosition());
-            directionLine.setyPosition(activePlayer.getBall().getyPosition());
-
+            directionLine.setPositionToBall(activePlayer.getBall());
+            
             int xPosition = (int) directionLine.getxPosition();
             int yPosition = (int) directionLine.getyPosition();
             int width = (int) directionLine.getWidth();
@@ -211,7 +210,6 @@ public class Model implements IModel, IEventListener {
 
             drawableEntities.add(new DrawableEntity(xPosition, yPosition, width, height, rotation, type));
         }
-
         return drawableEntities;
     }
 
@@ -265,7 +263,7 @@ public class Model implements IModel, IEventListener {
     public void shootBall(int power) {
         validateLevelIsSet();
 
-        activePlayer.shootBall(directionLine.getDegreeAngle(), power);
+        activePlayer.shootBall(Math.toRadians(directionLine.getDegreeAngle()), power);
         ballIsMoving = true;
         shotAllowed = false;
     }

--- a/crocket/src/main/java/com/crocket/model/Model.java
+++ b/crocket/src/main/java/com/crocket/model/Model.java
@@ -171,9 +171,7 @@ public class Model implements IModel, IEventListener {
         if (shotAllowed) {
             // TODO: Should be fixed. This is an ugly hack to get the direction line to show
             // up. Breaks Law of Demeter.
-            directionLine.setxPosition(activePlayer.getBall().getxPosition());
-            directionLine.setyPosition(activePlayer.getBall().getyPosition());
-
+            directionLine.setPositionToBall(activePlayer.getBall());
             directionLine.accept(visitor);
         }
         return visitor.getDrawableEntities();

--- a/crocket/src/main/java/com/crocket/model/Model.java
+++ b/crocket/src/main/java/com/crocket/model/Model.java
@@ -169,8 +169,6 @@ public class Model implements IModel, IEventListener {
         }
 
         if (shotAllowed) {
-            // TODO: Should be fixed. This is an ugly hack to get the direction line to show
-            // up. Breaks Law of Demeter.
             directionLine.setPositionToBall(activePlayer.getBall());
             directionLine.accept(visitor);
         }

--- a/crocket/src/main/java/com/crocket/model/Player.java
+++ b/crocket/src/main/java/com/crocket/model/Player.java
@@ -82,10 +82,10 @@ public class Player {
     }
 
     public void shootBall(double angle, double power) {
-        double sinus = Math.sin(Math.toRadians(angle));
-        double cosinus = Math.cos(Math.toRadians(angle));
+        double sinus = Math.sin(angle);
+        double cosinus = Math.cos(angle);
 
-        this.ball.startBall(sinus, cosinus, power);
+        this.ball.startBall(cosinus, sinus, power);
 
         incrementStrokes();
     }
@@ -100,6 +100,5 @@ public class Player {
 
     public Ball getBall() {
         return ball;
-
     }
 }

--- a/crocket/src/main/java/com/crocket/model/Player.java
+++ b/crocket/src/main/java/com/crocket/model/Player.java
@@ -4,7 +4,6 @@ import java.util.Queue;
 
 import com.crocket.model.entity.Ball;
 import com.crocket.model.entity.Entity;
-import com.crocket.model.interfaces.IEventListener;
 import java.util.LinkedList;
 import java.util.ArrayList;
 import java.util.List;

--- a/crocket/src/main/java/com/crocket/model/entity/Entity.java
+++ b/crocket/src/main/java/com/crocket/model/entity/Entity.java
@@ -1,6 +1,9 @@
 package com.crocket.model.entity;
 
-public abstract class Entity {
+import com.crocket.model.interfaces.IEntityVisitable;
+import com.crocket.model.interfaces.IEntityVisitor;
+
+public abstract class Entity implements IEntityVisitable {
     private double prevXPosition;
     private double prevYPosition;
     private double xPosition;
@@ -60,4 +63,7 @@ public abstract class Entity {
         return new Hitbox(width, height, xPosition, yPosition);
     }
 
+    public void accept(IEntityVisitor visitor) {
+        visitor.visit(this);
+    }
 }

--- a/crocket/src/main/java/com/crocket/model/entity/Hoop.java
+++ b/crocket/src/main/java/com/crocket/model/entity/Hoop.java
@@ -3,6 +3,7 @@ package com.crocket.model.entity;
 import com.crocket.model.EventPublisher;
 import com.crocket.model.PassTargetEvent;
 import com.crocket.model.interfaces.ICollidable;
+import com.crocket.model.interfaces.IEntityVisitor;
 import com.crocket.shared.Direction;
 import static com.crocket.shared.Direction.*;
 
@@ -105,13 +106,20 @@ public class Hoop extends Entity implements ICollidable {
     }
 
     public Hitbox getLeftHitbox() {
-        return new Hitbox(leftHitbox.getWidth(), leftHitbox.getHeight(), leftHitbox.getxPosition(),
-                leftHitbox.getyPosition());
+        return this.leftHitbox;
     }
 
     public Hitbox getRightHitbox() {
-        return new Hitbox(rightHitbox.getWidth(), rightHitbox.getHeight(), rightHitbox.getxPosition(),
-                rightHitbox.getyPosition());
+        return this.rightHitbox;
     }
 
+    public Direction getDirection() {
+        return this.dir;
+    }
+
+    // Weird bug should work in entity but IEntityVisitor does not use the overloaded method
+    @Override 
+    public void accept(IEntityVisitor visitor) {
+        visitor.visit(this);
+    }
 }

--- a/crocket/src/main/java/com/crocket/model/entity/Hoop.java
+++ b/crocket/src/main/java/com/crocket/model/entity/Hoop.java
@@ -106,11 +106,11 @@ public class Hoop extends Entity implements ICollidable {
     }
 
     public Hitbox getLeftHitbox() {
-        return this.leftHitbox;
+        return new Hitbox(leftHitbox.getWidth(), leftHitbox.getHeight(), leftHitbox.getxPosition(), leftHitbox.getyPosition());
     }
 
     public Hitbox getRightHitbox() {
-        return this.rightHitbox;
+        return new Hitbox(rightHitbox.getWidth(), rightHitbox.getHeight(), rightHitbox.getxPosition(),rightHitbox.getyPosition());
     }
 
     public Direction getDirection() {

--- a/crocket/src/main/java/com/crocket/model/interfaces/IEntityVisitable.java
+++ b/crocket/src/main/java/com/crocket/model/interfaces/IEntityVisitable.java
@@ -1,0 +1,16 @@
+package com.crocket.model.interfaces;
+
+/**
+ * The IEntityVisitable interface represents objects that can accept an IEntityVisitor.
+ * This is part of the Visitor design pattern, allowing different operations to be performed
+ * on an object without modifying its class.
+ */
+public interface IEntityVisitable {
+
+    /**
+     * Accepts a visitor, allowing it to perform operations on the implementing object.
+     *
+     * @param visitor the IEntityVisitor to accept
+     */
+    public void accept(IEntityVisitor visitor);
+}

--- a/crocket/src/main/java/com/crocket/model/interfaces/IEntityVisitor.java
+++ b/crocket/src/main/java/com/crocket/model/interfaces/IEntityVisitor.java
@@ -1,0 +1,36 @@
+package com.crocket.model.interfaces;
+
+import com.crocket.model.DirectionLine;
+import com.crocket.model.entity.Entity;
+import com.crocket.model.entity.Hoop;
+
+/**
+ * This interface is a visitor interface. It is a Visitor design pattern for entities.
+ * It declares visit methods for each concrete entity type.
+ */
+
+public interface IEntityVisitor {
+    
+    /**
+     * Visit method for a generic Entity object.
+     * 
+     * Default visit method for an Entity object.
+     *  
+     * @param entity the Entity object to be visited
+     */
+    public void visit(Entity entity); 
+    
+    /**
+     * Visit method for a Hoop object.
+     *
+     * @param hoop the Hoop object to be visited
+     */
+    public void visit(Hoop hoop);
+
+    /**
+     * Visit method for a DirectionLine object.
+     *
+     * @param directionLine the DirectionLine object to be visited
+     */
+    public void visit(DirectionLine directionLine);
+}

--- a/crocket/src/main/java/com/crocket/model/interfaces/IEventListener.java
+++ b/crocket/src/main/java/com/crocket/model/interfaces/IEventListener.java
@@ -3,8 +3,6 @@ package com.crocket.model.interfaces;
 import com.crocket.model.PassTargetEvent;
 import com.crocket.model.HitPowerUpEvent;
 
-import com.crocket.model.PassTargetEvent;
-import com.crocket.model.HitPowerUpEvent;
 
 /**
  * The IEventListener interface represents a listener for target events (like hitting a hop or a peg) in the game.
@@ -13,7 +11,17 @@ import com.crocket.model.HitPowerUpEvent;
  * This interface is expected to be implemented by classes that need to respond to target events.
  */
 public interface IEventListener {
+    /**
+     * Handles a PassTargetEvent.
+     * 
+     * @param event
+     */
     public void handleEvent(PassTargetEvent event);
-    
+
+    /**
+     * Handles a HitPowerUpEvent.
+     * 
+     * @param event
+     */
     public void handleEvent(HitPowerUpEvent event);
 }

--- a/crocket/src/main/java/com/crocket/model/interfaces/IPowerUp.java
+++ b/crocket/src/main/java/com/crocket/model/interfaces/IPowerUp.java
@@ -3,5 +3,10 @@ package com.crocket.model.interfaces;
 import com.crocket.model.entity.Ball;
 
 public interface IPowerUp {
+    /**
+     * Applies the power up to the ball.
+     * 
+     * @param ball the ball to apply the power up to
+     */
     public void applyPowerUp(Ball ball);
 }

--- a/crocket/src/main/java/com/crocket/view/CroquetView.java
+++ b/crocket/src/main/java/com/crocket/view/CroquetView.java
@@ -3,20 +3,6 @@ import javax.swing.JFrame;
 
 import javax.swing.ImageIcon;
 
-/*
- * Class: CroquetView
- * 
- * This class extends JFrame and represents the main window of the game. It is responsible for 
- * rendering the game state to the user.
- * 
- * CroquetView is implemented as a Singleton, ensuring that only one instance of CroquetView exists
- * in the application at any time. This is done to maintain a consistent view state throughout
- * the application.
- * 
- * Methods:
- * setLevelView: Sets the current level view to the specified LevelView object. Clears the frame
- */
-
 public class CroquetView extends JFrame{
     private static CroquetView instance;
     private ImageIcon img = new ImageIcon("crocket/assets/textures/JFrame_Icon.jpg");

--- a/crocket/src/main/java/com/crocket/view/CroquetView.java
+++ b/crocket/src/main/java/com/crocket/view/CroquetView.java
@@ -1,9 +1,7 @@
 package com.crocket.view;
-import javax.swing.*;
+import javax.swing.JFrame;
 
-import java.awt.Dimension;
-import java.awt.Toolkit;
-
+import javax.swing.ImageIcon;
 
 /*
  * Class: CroquetView
@@ -17,27 +15,13 @@ import java.awt.Toolkit;
  * 
  * Methods:
  * setLevelView: Sets the current level view to the specified LevelView object. Clears the frame
- * setBallToLevel: Sets the ball to the specified DrawEntity object.
- * 
- * 
- * Problems:
- * CroquetView can only have one DrawEntity object at a time. Might be problems later when we add multiplayer. 
- * 
- * 
  */
 
 public class CroquetView extends JFrame{
     private static CroquetView instance;
     private ImageIcon img = new ImageIcon("crocket/assets/textures/JFrame_Icon.jpg");
-    private Dimension screen = Toolkit.getDefaultToolkit().getScreenSize();
     private String title = "Krocket";
-    private DrawBall ball;
     private LevelView levelView;
-    private DrawStone stone;
-    DrawDirectionLine line = new DrawDirectionLine();
-    PowerPanel pPanel = new PowerPanel();
-    
-    
     
     public void setLevelView(LevelView level) {
         if (getContentPane() != null) {
@@ -48,36 +32,11 @@ public class CroquetView extends JFrame{
         revalidate();
     }
 
-    public void setBallToLevel(DrawBall ball){
-        try{
-            this.ball = ball;
-            levelView.add(ball);
-            levelView.add(line);
-            levelView.add(pPanel);
-            
-        }
-        catch(NullPointerException e){
-            System.out.println("No container found!");
-        }
-    }
-
-    public void setStoneToLevel(DrawStone stone){
-        try{
-            this.stone = stone;
-            levelView.add(stone);
-        }
-        catch(NullPointerException e){
-            System.out.println("No container found!");
-        }
-    }
-
     private CroquetView(){
         setIconImage(img.getImage());
         setTitle(title);
         setVisible(true);
-        setLocationRelativeTo(null);
         setExtendedState(MAXIMIZED_BOTH); 
-
         setDefaultCloseOperation(EXIT_ON_CLOSE);
     }
 
@@ -89,46 +48,15 @@ public class CroquetView extends JFrame{
         return instance;
     }
 
-    public DrawBall getEntity(){
-        return ball;
-    }
-
-    public void setStone(int x, int y){
-        stone.setLocation(x, y);
-    }
-
-    public void moveBall(int x, int y){
-        ball.setLocation(x, y);
-    }
-
-    public void setPowerMeterVisibility(boolean vis){
-        pPanel.setVisible(vis);
-    }
-
     public void incrementIndicator(){
-        pPanel.incrementIndicator();
-        pPanel.repaint();
+        levelView.incrementPowerIndicator();
     }
 
     public void decrementIndicator(){
-        pPanel.decrementIndicator();
-        pPanel.repaint();
+        levelView.decrementPowerIndicator();
     }
 
     public void resetIndicator(){
-        pPanel.resetIndicator();
-        pPanel.repaint();
+        levelView.resetPowerIndicator();
     }
-
-    public void updateLine(int xPos, int yPos, int xAngle, int yAngle){
-        line.setSize(100, 100);
-        line.setLocation(xPos-line.getStartX(), yPos-line.getStartY());
-        line.changeAngle(xAngle + (line.getStartX()), yAngle + (line.getStartY()));
-        line.repaint();
-    }
-
-    public void updatePowerMeter(){
-        pPanel.setLocation(30, (int)screen.getHeight() - 100);
-    }
-
 }

--- a/crocket/src/main/java/com/crocket/view/DrawDirectionLine.java
+++ b/crocket/src/main/java/com/crocket/view/DrawDirectionLine.java
@@ -8,36 +8,31 @@ import javax.swing.JPanel;
 
 public class DrawDirectionLine extends JPanel {
     
-    private int startX = 50;
-    private int startY = 50;
+    public static final int WIDTH = 100;
+    public static final int HEIGHT = 100;
+    private final int STARTX = 50;
+    private final int STARTY = 50;
+    private final int LINE_COEFFICIENT = 1000;
     private int endX;
     private int endY;
 
-    DrawDirectionLine(){
+    DrawDirectionLine() {
         super();
         setOpaque(false);
     }
-    
-    public int getStartX() {
-        return startX;
-    }
 
-    public int getStartY() {
-        return startY;
-    }
-
-    public void changeAngle(int x, int y){
-        endX = x;
-        endY = y;
+    public void changeAngle(double x, double y) {
+        endX = (int)(LINE_COEFFICIENT * x);
+        endY = (int)(LINE_COEFFICIENT * y);
     }
 
     @Override
-    public void paintComponent(Graphics g){
+    public void paintComponent(Graphics g) {
         super.paintComponent(g);
         Graphics2D g2 = (Graphics2D) g;
         g2.setColor(Color.BLACK);
         g2.setStroke(new BasicStroke(2));
-        g2.drawLine(startX, startY, endX, endY);
+        g2.drawLine(STARTX, STARTY, endX, endY);
         
     }
 }

--- a/crocket/src/main/java/com/crocket/view/LevelView.java
+++ b/crocket/src/main/java/com/crocket/view/LevelView.java
@@ -55,6 +55,7 @@ public class LevelView extends JLayeredPane implements ILevelView, IModelVisuali
 
     private void drawLowerLayerEntity(DrawableEntity entity, BufferedImage bufferedImage) {
         JLabel label = makeLabel(entity, bufferedImage);
+        label.setBackground(Color.RED);
         add(label, JLayeredPane.DEFAULT_LAYER);
     }
 
@@ -63,7 +64,7 @@ public class LevelView extends JLayeredPane implements ILevelView, IModelVisuali
         add(label, JLayeredPane.MODAL_LAYER);
     }
 
-    private void drawNoneLayeredEntity(DrawableEntity entity) {
+    private void drawLowerLayeredEntity(DrawableEntity entity) {
         BufferedImage bufferedImage = textureManager.getTexture(entity.getTypeName());
         drawLowerLayerEntity(entity, bufferedImage);
     }
@@ -156,10 +157,10 @@ public class LevelView extends JLayeredPane implements ILevelView, IModelVisuali
                 drawMiddleLayerEntity(entity, textureManager.getTexture(entity.getTypeName()));
                 return;
             case BALL:
-                drawNoneLayeredEntity(entity);
+                drawLowerLayeredEntity(entity);
                 return;
             case STONE:
-                drawNoneLayeredEntity(entity);
+                drawLowerLayeredEntity(entity);
                 return;
             case DIRECTIONLINE:
                 drawDirectionLine(entity);

--- a/crocket/src/main/java/com/crocket/view/LevelView.java
+++ b/crocket/src/main/java/com/crocket/view/LevelView.java
@@ -19,11 +19,13 @@ public class LevelView extends JLayeredPane implements ILevelView, IModelVisuali
     private TextureManager textureManager;
     private int levelHeight;
     private int levelWidth;
+    private PowerPanel powerPanel;
 
     public LevelView() {
         setDoubleBuffered(true);
         this.textureManager = new TextureManager();
         this.textureManager.loadTextures();
+        powerPanel = new PowerPanel();
     }
 
     @Override
@@ -72,11 +74,34 @@ public class LevelView extends JLayeredPane implements ILevelView, IModelVisuali
         return label;
     }
     
-    // TODO: FIX THIS!!!!
     private void drawDirectionLine(DrawableEntity entity) {
-     
+        DrawDirectionLine panel = new DrawDirectionLine();
+        panel.setBounds(entity.getxPosition(), entity.getyPosition(), DrawDirectionLine.WIDTH, DrawDirectionLine.HEIGHT);
+        
+        panel.changeAngle(entity.getCosinus(), entity.getSinus());
+        add(panel, JLayeredPane.DEFAULT_LAYER);
+        panel.repaint();
     }
 
+    private void drawPowerMeter() {
+        powerPanel.setBounds(powerPanel.getXPOS(), powerPanel.getYPOS(), powerPanel.getWidth(), powerPanel.getHeight());
+        add(powerPanel, MODAL_LAYER);
+    }
+
+    public void incrementPowerIndicator() {
+        powerPanel.incrementIndicator();
+        powerPanel.repaint();
+    }
+
+    public void decrementPowerIndicator() {
+        powerPanel.decrementIndicator();
+        powerPanel.repaint();
+    }
+
+    public void resetPowerIndicator() {
+        powerPanel.resetIndicator();
+        powerPanel.repaint();
+    }
 
     private void getHoopTexture(DrawableEntity entity) {
         int rotation = entity.getRotation();
@@ -138,6 +163,7 @@ public class LevelView extends JLayeredPane implements ILevelView, IModelVisuali
                 return;
             case DIRECTIONLINE:
                 drawDirectionLine(entity);
+                drawPowerMeter();
                 return;
             default:
                 throw new IllegalArgumentException("Unknown entity class: " + entity.getTypeName());

--- a/crocket/src/main/java/com/crocket/view/PowerPanel.java
+++ b/crocket/src/main/java/com/crocket/view/PowerPanel.java
@@ -3,8 +3,10 @@ package com.crocket.view;
 
 import java.awt.BasicStroke;
 import java.awt.Color;
+import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
+import java.awt.Toolkit;
 
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
@@ -12,21 +14,41 @@ import javax.swing.JPanel;
 
 public class PowerPanel extends JPanel {
     
+    private Dimension screen = Toolkit.getDefaultToolkit().getScreenSize();
     private ImageIcon powerImg = new ImageIcon("crocket/assets/textures/PowerMeter.png");
     private JLabel powerLabel = new JLabel();
+    private final int WIDTH = 200;
+    private final int HEIGHT = 50;
+    private final int XPOS = (int) screen.getWidth()/100;
+    private final int YPOS = 90 * (int) screen.getHeight()/100;
     private int[] x = new int[] {0,3,6};
     private int[] y = new int[] {55,25,55};
     
-    PowerPanel(){
+    PowerPanel() {
         super();
         powerLabel.setIcon(powerImg);
         add(powerLabel);
         setOpaque(false);
         setLocation(100, 100);
-        setVisible(false);
+    }
+    
+    public int getXPOS() {
+        return XPOS;
     }
 
-    public void resetIndicator(){
+    public int getYPOS() {
+        return YPOS;
+    }
+
+    public int getWidth() {
+        return WIDTH;
+    }
+
+    public int getHeight() {
+        return HEIGHT;
+    }
+
+    public void resetIndicator() {
         x[0] = 0;
         x[1] = 3;
         x[2] = 6;
@@ -45,7 +67,7 @@ public class PowerPanel extends JPanel {
     }
 
     @Override
-    public void paintChildren(Graphics g){
+    public void paintChildren(Graphics g) {
         super.paintChildren(g);
         Graphics2D g2 = (Graphics2D) g;
         g2.setStroke(new BasicStroke(2));

--- a/crocket/src/test/java/com/crocket/DirectionLineTest.java
+++ b/crocket/src/test/java/com/crocket/DirectionLineTest.java
@@ -9,11 +9,11 @@ import com.crocket.model.DirectionLine;
 import static org.junit.Assert.assertEquals;
 
 public class DirectionLineTest {
-    private DirectionLine directionLine = new DirectionLine(90, 20, 20, 20, 2);
+    private DirectionLine directionLine = new DirectionLine(90, 20, 20);
 
     @Before
     public void reset_directionline(){
-        directionLine = new DirectionLine(90, 20, 20, 20, 2);
+        directionLine = new DirectionLine(90, 20, 20);
     }
 
     @Test

--- a/crocket/src/test/java/com/crocket/PlayerTest.java
+++ b/crocket/src/test/java/com/crocket/PlayerTest.java
@@ -4,7 +4,7 @@ package com.crocket;
 
 import org.junit.Test;
 
-import com.crocket.model.PassTargetEvent;
+
 import com.crocket.model.Player;
 import com.crocket.model.entity.Ball;
 import com.crocket.model.entity.Entity;

--- a/crocket/src/test/java/com/crocket/model/surface/SurfaceHandlerTest.java
+++ b/crocket/src/test/java/com/crocket/model/surface/SurfaceHandlerTest.java
@@ -3,8 +3,6 @@ package com.crocket.model.surface;
 import com.crocket.model.entity.Ball;
 import com.crocket.shared.SurfaceType;
 import com.crocket.model.Level1;
-
-import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
# Added visitor pattern to drawable entities

## Description
This code introduces the use of the Visitor design pattern to handle the drawing of various entities in the model. This approach eliminates the need for extensive if-else conditions when dealing with entities that have custom features. The visitor takes the entities and attempts to create new custom drawable entities using method overloading. 

Also fixed rotation of hoops. The view can now draw any hoop (You need to change the width and height in reverse when making a eastwestHoop otherwise it will be cut off)

**However, there's an issue with the `Hoop` class. Ideally, when the accept method of `Entity` is called, it should pass the Hoop instance to the `EntityVisitor,` which should then invoke the overloaded visit(Hoop hoop) method. But this isn't happening. For some reason, we need to override the accept method in the `Hoop` class to prevent it from using the accept method in the `Entity` superclass, even if the `Entity` uses `this` which is hoop.**


Closes #95 